### PR TITLE
fix: Used join function to fix vault id argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "azurerm_key_vault" "key_vault" {
 resource "azurerm_key_vault_secret" "key_vault_secret" {
   depends_on   = [azurerm_key_vault.key_vault, azurerm_role_assignment.rbac_user_assigned]
   for_each     = var.secrets
-  key_vault_id = azurerm_key_vault.key_vault.*.id
+  key_vault_id = join("", azurerm_key_vault.key_vault.*.id)
   name         = each.key
   value        = each.value
   tags         = module.labels.tags


### PR DESCRIPTION
## what
* Utilizing the 'join' parameter when passing the Key Vault ID as an argument in the Key Vault secret resource.

## why
* By utilizing the 'join' parameter, ensuring a smooth execution without any unexpected errors. 
