### PR TITLE
ci: Fix node-version in sementic-release workflow

### DIFF
--- a/.github/workflows/semantic-releaser.yml
+++ b/.github/workflows/semantic-releaser.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Release
         env:


### PR DESCRIPTION
## what
* Updated node version in sementic-release workflow.

## why
* To prevent static checks fail while new release.