### PR TITLE
Feat/extra_tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ module "labels" {
   managedby   = var.managedby
   label_order = var.label_order
   repository  = var.repository
-  extra_tags = var.extra_tags
+  extra_tags  = var.extra_tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ module "labels" {
   managedby   = var.managedby
   label_order = var.label_order
   repository  = var.repository
+  extra_tags = var.extra_tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -31,9 +31,9 @@ variable "managedby" {
 }
 
 variable "extra_tags" {
-type = map(string)
-default = null
-description = "Variable to pass extra tags."
+  type        = map(string)
+  default     = null
+  description = "Variable to pass extra tags."
 }
 
 variable "enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -260,3 +260,8 @@ variable "network_acls" {
   })
   default = {}
 }
+variable "extra_tags" {
+type = map(string)
+default = null
+description = "Variable to pass extra tags."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,12 @@ variable "managedby" {
   description = "ManagedBy, eg ''."
 }
 
+variable "extra_tags" {
+type = map(string)
+default = null
+description = "Variable to pass extra tags."
+}
+
 variable "enabled" {
   type        = bool
   description = "Set to false to prevent the module from creating any resources."
@@ -259,9 +265,4 @@ variable "network_acls" {
     virtual_network_subnet_ids = optional(list(string)),
   })
   default = {}
-}
-variable "extra_tags" {
-type = map(string)
-default = null
-description = "Variable to pass extra tags."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -261,7 +261,7 @@ variable "network_acls" {
   default = {}
 }
 variable "extra_tags" {
-type = map(string)
+type = map(list)
 default = null
 description = "Variable to pass extra tags."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -261,7 +261,7 @@ variable "network_acls" {
   default = {}
 }
 variable "extra_tags" {
-type = map(list)
+type = map(string)
 default = null
 description = "Variable to pass extra tags."
 }


### PR DESCRIPTION
## what
- Add custom tags

## why
- Azure Modules only support tags from module.labels.tags, we want that any user to pass their custom tags.
