### PR TITLE
Added Details of Private DNS Zone Group.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -217,6 +217,12 @@ resource "azurerm_private_endpoint" "pep" {
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_id
   tags                = module.labels.tags
+
+  private_dns_zone_group {
+    name                 = format("%s-sa-dns-zone-group", module.labels.id)
+    private_dns_zone_ids = var.existing_private_dns_zone == null ? [azurerm_private_dns_zone.dnszone[0].id] : [var.existing_private_dns_zone_id]
+  }
+  
   private_service_connection {
     name                           = format("%s-psc-kv", module.labels.id)
     is_manual_connection           = false
@@ -314,48 +320,6 @@ resource "azurerm_private_dns_zone_virtual_network_link" "addon_vent_link" {
   private_dns_zone_name = var.existing_private_dns_zone == null ? azurerm_private_dns_zone.dnszone[0].name : var.existing_private_dns_zone
   virtual_network_id    = var.addon_virtual_network_id
   tags                  = module.labels.tags
-}
-
-##----------------------------------------------------------------------------- 
-## Below resource will create dns A record for private ip of private endpoint in private dns zone. 
-##-----------------------------------------------------------------------------
-resource "azurerm_private_dns_a_record" "arecord" {
-  provider = azurerm.main_sub
-  count    = var.enabled && var.enable_private_endpoint && var.diff_sub == false ? 1 : 0
-
-  name                = azurerm_key_vault.key_vault[0].name
-  zone_name           = local.private_dns_zone_name
-  resource_group_name = local.valid_rg_name
-  ttl                 = 3600
-  records             = [data.azurerm_private_endpoint_connection.private-ip[0].private_service_connection[0].private_ip_address]
-  tags                = module.labels.tags
-  lifecycle {
-    ignore_changes = [
-      tags,
-    ]
-  }
-}
-
-##----------------------------------------------------------------------------- 
-## Below resource will create dns A record for private ip of private endpoint in private dns zone. 
-## This resource will be created when private dns is in different subscription. 
-##-----------------------------------------------------------------------------
-resource "azurerm_private_dns_a_record" "arecord-1" {
-  provider = azurerm.dns_sub
-  count    = var.enabled && var.enable_private_endpoint && var.diff_sub == true ? 1 : 0
-
-
-  name                = azurerm_key_vault.key_vault[0].name
-  zone_name           = local.private_dns_zone_name
-  resource_group_name = local.valid_rg_name
-  ttl                 = 3600
-  records             = [data.azurerm_private_endpoint_connection.private-ip[0].private_service_connection[0].private_ip_address]
-  tags                = module.labels.tags
-  lifecycle {
-    ignore_changes = [
-      tags,
-    ]
-  }
 }
 
 ##----------------------------------------------------------------------------- 

--- a/variables.tf
+++ b/variables.tf
@@ -155,6 +155,12 @@ variable "existing_private_dns_zone_resource_group_name" {
   description = "The name of the existing resource group"
 }
 
+variable "existing_private_dns_zone_id" {
+  description = "The ID of an existing private DNS zone."
+  type        = string
+  default     = null
+}
+
 variable "public_network_access_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* Added support for managing Private DNS Zone Group within the module.
* Conditionally link to an existing Private DNS Zone or create a new one based on the provided input (var.existing_private_dns_zone).

## why
* Create a new Private DNS Zone if no existing zone is provided, or
* Link to an existing Private DNS Zone, which aligns with use cases where a shared DNS zone is required across multiple VNets or projects.

